### PR TITLE
environment: new prefix for project related environment variables

### DIFF
--- a/bcc.py
+++ b/bcc.py
@@ -32,12 +32,12 @@ class Bcc(object):
         port / FTDI cable. 
     """
     
-    def __init__(self, port = os.getenv("GORDON_BCTRL_PORT", "/dev/ttyUSB0"), speed = 57600, drbcc = "drbcc"):
+    def __init__(self, port = os.getenv("MONK_BCTRL_PORT", "/dev/ttyUSB0"), speed = 57600, drbcc = "drbcc"):
         """ Create a new BCC instance.
 
             :param port:  serial port to use for communication with the board
                           controller, defaults to content of environment
-                          variable GORDON_BCTRL_PORT or "/dev/ttyUSB0" if the
+                          variable MONK_BCTRL_PORT or "/dev/ttyUSB0" if the
                           variable is not set
             :param speed: serial port speed
             :param drbcc: path to drbcc binary

--- a/connection.py
+++ b/connection.py
@@ -25,7 +25,7 @@ class Connection(object):
         It implements device command processing in a request/response manner.
     """
 
-    def __init__(self, serial_setup = (os.getenv("GORDON_CONSOLE_PORT", "/dev/ttyUSB1"), 115200, 8, 'N', 1, 1), 
+    def __init__(self, serial_setup = (os.getenv("MONK_CONSOLE_PORT", "/dev/ttyUSB1"), 115200, 8, 'N', 1, 1), 
                  network_setup = ( None, "eth0" ), login = ( "root", "" ),
                  boot_prompt = "HidaV boot on", serial_skip_pw = True,
                  reset_cb = None):

--- a/doc/source/test-framework.rst
+++ b/doc/source/test-framework.rst
@@ -66,6 +66,6 @@ Environment Variables
 =================== ============ =================================================
 Variable            Default      Description
 =================== ============ =================================================
-GORDON_BCTRL_PORT   /dev/ttyUSB0 serial port, the board controller is connected to
-GORDON_CONSOLE_PORT /dev/ttyUSB1 serial port, device console is connected to
+MONK_BCTRL_PORT     /dev/ttyUSB0 serial port, the board controller is connected to
+MONK_CONSOLE_PORT   /dev/ttyUSB1 serial port, device console is connected to
 =================== ============ =================================================


### PR DESCRIPTION
### Problem

The project was renamed from GORDON to MONK, but all related environment variables still have the prefix GORDON_.
### Solution

Rename all environment variables and update documentation.
