### PR TITLE
Login problems over serial connection

### DIFF
--- a/serial_conn.py
+++ b/serial_conn.py
@@ -75,7 +75,6 @@ class SerialConn(serial.Serial):
         if timeout:
             old_to = self._timeout
             self._timeout = timeout
-        self.write("\n")
         while not target in buf:
             ret = self.read()
             if ret == "":


### PR DESCRIPTION
**Problem:**

The login on _hipox_ machine which requires _username_ and _password_ often results in endless read loops.

**Solution:**

These two commits in this branch fix the `read_until` handling by removing a useless/counterproductive _\n_ sending and change the write_trigger to a more useful/correct string.

The solution might improve #3 
