### PR TITLE
Login problems over serial connection (Part II)

### DIFF
--- a/serial_conn.py
+++ b/serial_conn.py
@@ -175,8 +175,7 @@ class SerialConn(serial.Serial):
         self.flushInput()
         self.flushOutput()
 
-        # use ^D aka \003 as write_trigger for login prompt
-        self.read_until("login:", "\003", timeout=20)
+        self.read_until("login:", "\n", timeout=20)
         self.write(self._login[0] + "\n")
 
         if not self._skip_pass:


### PR DESCRIPTION
The decision to use ^D as login write_trigger was not really good.
It seems that depending on the buffer management the trigger string
may be suspended for a long time. This is fixed by using \n instead.

Signed-off-by: Steffen Sledz sledz@dresearch-fe.de
Acked-by: Sascha Dierberg dierberg@dresearch-fe.de
Acked-by: Mario Schuknecht schuknecht@dresearch-fe.de
