### PR TITLE
requirements-*.txt: some minor changes for Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ python:
  - "2.7"
 
 install:
- - "pip install -r test-env.txt"
+ - "pip install -r requirements-test.txt"
  - "python setup.py develop"
 
 script:
  - "python setup.py nosetests"
+ - "python setup.py lint || [ \"$?\" -ne 32 ]"
 
 before_install:
  - "sudo apt-get install python2.7-dev libssh2-1-dev"

--- a/development-env.txt
+++ b/development-env.txt
@@ -1,9 +1,0 @@
-Jinja2==2.6
-Pygments==1.6
-Sphinx==1.2b1
-argparse==1.2.1
-distribute==0.6.34
-docutils==0.10
-pylibssh2==1.0.1
-pyserial==2.5
-wsgiref==0.1.2

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -1,0 +1,3 @@
+Sphinx==1.2b1
+pylibssh2==1.0.1
+pyserial==2.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+nose==1.3.0
+coverage==3.6
+nosexcover==1.0.8
+setuptools-lint==0.1

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,6 @@ setup(
     author_email = "project-monk@dresearch-fe.de",
     url="https://github.com/DFE/MONK",
     packages=[project],
-    setup_requires = [
-        "nose >= 1.0"
-    ],
     install_requires = [
         "pyserial >=2.5",
         "pylibssh2 >=1.0.1"

--- a/test-env.txt
+++ b/test-env.txt
@@ -1,6 +1,0 @@
-argparse==1.2.1
-coverage==3.6
-distribute==0.6.34
-nose==1.3.0
-nosexcover==1.0.8
-wsgiref==0.1.2


### PR DESCRIPTION
To apply the new test environment to our Jenkins job, some minor changes had to
be made. A setuptools command for pylint was installed, that pylint can be
started like all the commands via `python setup.py <command>`. This will
automatically add pylint itself to the requirements.

For testing and for developing there are now 2 requirement files:
- requirements-develop.txt
- requirements-test.txt

Advantage for this is, that everything is installed with pip and everybody
should use the same versions for their tests/development env. Disadvantage is
that from time to time someone needs to update those files.

Signed-off-by: Erik Bernoth erik.bernoth@gmail.com
